### PR TITLE
#7484 - Update to set Project fields read-only

### DIFF
--- a/assets/staffportal/json/project-form/project-form-json-config-vlb.json
+++ b/assets/staffportal/json/project-form/project-form-json-config-vlb.json
@@ -1,0 +1,86 @@
+{
+  "tags": [
+    "ProjectForm",
+    "StaffPortal",
+    "VLB"
+  ],
+  "version": "1.2.0",
+  "name": "Veterinary and Veterinary Technologists Locums Working in BC Food Animal Practices Pilot Program",
+  "abbreviation": "VLB",
+  "tabs": [
+    {
+      "name": "projectReviewTab",
+      "sections": [
+        {
+          "name": "agreementSignedSection",
+          "fields": [
+            {
+              "name": "quartech_contributionagreement",
+              "visible": false
+            },
+            {
+              "name": "quartech_projectapproval",
+              "label": "Project Approval sent to Applicant"
+            }
+          ]
+        },
+        {
+          "name": "claimProcessingSection",
+          "fields": [
+            {
+              "name": "quartech_allinvoicesreceiptsreceived",
+              "visible": false
+            },
+            {
+              "name": "quartech_eventreportreceived",
+              "visible": false
+            },
+            {
+              "name": "quartech_itemizedexpenselistreceived",
+              "visible": false
+            },
+            {
+              "name": "quartech_reimbursementverified",
+              "visible": false
+            }
+          ]
+        },
+        {
+          "name": "paymentSection",
+          "fields": [
+            {
+              "name": "quartech_eaapprovalsent",
+              "visible": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "claimsTab",
+      "sections": [
+        {
+          "name": "claimsTab_section_FiscalYearData",
+          "visible": true
+        }
+      ]
+    },
+    {
+      "name": "generalTab",
+      "sections": [
+        {
+          "name": "section_Funding",
+          "fields": [
+            {
+              "name": "quartech_requestedfunding",
+              "disabled": true
+            },
+            {
+              "name": "quartech_approvedamount",
+              "disabled": true
+            }
+          ]
+        }
+      ]
+    }
+  ]


### PR DESCRIPTION
These changes must affect the VLB records only:
Users must not enter the Requested Funding data in the Project record. Users must not enter the Approved Amount  data in the Project record.